### PR TITLE
Add message list with like interaction

### DIFF
--- a/wp-content/themes/mi-tema/style.css
+++ b/wp-content/themes/mi-tema/style.css
@@ -3,3 +3,24 @@ Theme Name: mi-tema
 Author: Codex
 Version: 1.0
 */
+
+.mi-mensaje {
+    margin-bottom: 20px;
+}
+
+.mi-mensaje .heart {
+    color: #ccc;
+    cursor: pointer;
+    font-size: 20px;
+    background: none;
+    border: none;
+    padding: 0;
+}
+
+.mi-mensaje .heart.liked {
+    color: red;
+}
+
+.mi-mensaje .like-count {
+    margin-left: 5px;
+}

--- a/wp-content/themes/mi-tema/zonas_comunes.php
+++ b/wp-content/themes/mi-tema/zonas_comunes.php
@@ -53,11 +53,30 @@ function mitema_display_mensajes() {
 
     ob_start();
     if ($entries) {
+        echo '<div class="mi-mensajes">';
         foreach ($entries as $e) {
             $likes = intval($e->likes);
             $liked_users = $e->liked_users ? explode(',', $e->liked_users) : [];
             $already_liked = is_user_logged_in() && in_array(get_current_user_id(), $liked_users);
+
+            echo '<div class="mi-mensaje">';
+            echo '<p><strong>' . esc_html($e->nombre) . ' (' . esc_html($e->area) . '):</strong> ' . esc_html($e->mensaje) . '</p>';
+
+            if ($already_liked) {
+                echo '<span class="heart liked">&#x2764;</span>';
+                echo '<span class="like-count">' . $likes . '</span>';
+            } else {
+                echo '<form method="post" class="like-form">';
+                wp_nonce_field('mi_like_action', 'mi_like_nonce');
+                echo '<input type="hidden" name="mi_like_id" value="' . intval($e->id) . '" />';
+                echo '<button type="submit" class="heart">&#x2764;</button>';
+                echo '<span class="like-count">' . $likes . '</span>';
+                echo '</form>';
+            }
+
+            echo '</div>';
         }
+        echo '</div>';
     } else {
         echo '<p>No hay mensajes.</p>';
     }


### PR DESCRIPTION
## Summary
- show messages with names, areas and text
- show like counts with active/inactive heart indicator
- add minimal styles for message list and hearts

## Testing
- `php` not installed, so no syntax check was performed

------
https://chatgpt.com/codex/tasks/task_e_685858c6ea6c83309c83a8ff8e50824d